### PR TITLE
Qt5QMLPlugin_Example: not creating modules without a library and depending on them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,14 @@ qt5_add_executable(${PROJECT_NAME}
    ${QRC_FILES_IMAGES}
 )
 
+qt5_add_qml_module(${PROJECT_NAME}
+    URI "org.example.test"
+    VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
+    RESOURCE_PREFIX "/${RELATIVE_DIR}"
+    QML_FILES
+    ${CMAKE_SOURCE_DIR}/qml/Circle.qml
+)
+
 target_compile_definitions(${PROJECT_NAME} PRIVATE
     $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>
     SUBMODULE_IMPORT_PATH="${SUBMODULE_IMPORT_PATH}"

--- a/qml/Circle.qml
+++ b/qml/Circle.qml
@@ -1,0 +1,12 @@
+import QtQuick 2.15
+
+Rectangle {
+    id: root
+
+    required property int size
+
+    implicitHeight: root.size
+    implicitWidth: root.size
+
+    radius: root.width
+}

--- a/qml/Pages/Menu/MainMenuPage_Form.ui.qml
+++ b/qml/Pages/Menu/MainMenuPage_Form.ui.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts 1.15
 import Common 1.0 as Common
 import Forms 1.0 as Forms
 import org.example.core 1.0 as Core
+import org.example.test 1.0 as Test
 
 Forms.BaseForm {
     id: formMainMenuPage
@@ -47,11 +48,15 @@ Forms.BaseForm {
                 source: "qrc:/images/res/images/cool_cat.png"
             }
 
+            ColorCircle {}
+
             Image {
                 sourceSize.width: cool_cat.width; sourceSize.height: cool_cat.height
                 fillMode: Image.PreserveAspectFit
                 source: "qrc:/images/res/images/cool_cat_with_headsets.png"
             }
+
+            ColorCircle {}
 
             Image {
                 sourceSize.width: cool_cat.width; sourceSize.height: cool_cat.height
@@ -90,4 +95,9 @@ Forms.BaseForm {
             } // Connections
         } // RoundButton
     } // ColumnLayout
+
+    component ColorCircle: Test.Circle {
+        color: "#282828"
+        size: 100
+    }
 } // Forms.BaseForm


### PR DESCRIPTION
@mentalfl0w Colleague, good evening. I found the cause of the issue where adding a module doesn't work without using a library.

<details>

<summary>console</summary>

```sh
Change Dir: '/home/dika/Project/Qt5QMLPlugin_Example/build'

Run Build Command(s): /usr/bin/ninja -v all
[1/6] cd /home/dika/Project/Qt5QMLPlugin_Example/build/qml/src && /usr/bin/cmake -E env QML2_IMPORT_PATH="/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/org/example" /usr/lib/x86_64-linux-gnu/qt5/bin/qmlplugindump -nonrelocatable org.example.core 1.0 /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/org/example -output /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/org/example/core/org_example_core.qmltypes
[2/6] cd /home/dika/Project/Qt5QMLPlugin_Example/build/qml/Common && /usr/bin/cmake -E env QML2_IMPORT_PATH="/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml" /usr/lib/x86_64-linux-gnu/qt5/bin/qmlplugindump -nonrelocatable Common 1.0 /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml -output /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/Common/Common.qmltypes
[3/6] : && /usr/bin/c++   CMakeFiles/StackView-Template.dir/StackView-Template_autogen/mocs_compilation.cpp.o CMakeFiles/StackView-Template.dir/main.cpp.o CMakeFiles/StackView-Template.dir/qrc_qmls.cpp.o CMakeFiles/StackView-Template.dir/qrc_images.cpp.o CMakeFiles/StackView-Template.dir/qrc_org_example_test.cpp.o -o StackView-Template  -Wl,-rpath,/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary/Forms:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary/Components:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/Common:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/Pages:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/org/example/core  output/qml/UILibrary/Forms/libFormsLib.so  output/qml/UILibrary/Components/libComponentsLib.so  output/qml/Common/libCommon.so  output/qml/Pages/libPages.so  output/qml/org/example/core/libCoreLib.so  /usr/lib/x86_64-linux-gnu/libQt5Quick.so.5.15.13  /usr/lib/x86_64-linux-gnu/libQt5QmlModels.so.5.15.13  /usr/lib/x86_64-linux-gnu/libQt5Qml.so.5.15.13  /usr/lib/x86_64-linux-gnu/libQt5Network.so.5.15.13  /usr/lib/x86_64-linux-gnu/libQt5Gui.so.5.15.13  /usr/lib/x86_64-linux-gnu/libQt5Core.so.5.15.13 && :
[4/6] cd /home/dika/Project/Qt5QMLPlugin_Example/build/qml/UILibrary/Components && /usr/bin/cmake -E env QML2_IMPORT_PATH="/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary" /usr/lib/x86_64-linux-gnu/qt5/bin/qmlplugindump -nonrelocatable Components 1.0 /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary -output /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary/Components/Components.qmltypes
FAILED: qml/UILibrary/Components/CMakeFiles/Componentspluginqmltypes /home/dika/Project/Qt5QMLPlugin_Example/build/qml/UILibrary/Components/CMakeFiles/Componentspluginqmltypes 
cd /home/dika/Project/Qt5QMLPlugin_Example/build/qml/UILibrary/Components && /usr/bin/cmake -E env QML2_IMPORT_PATH="/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary" /usr/lib/x86_64-linux-gnu/qt5/bin/qmlplugindump -nonrelocatable Components 1.0 /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary -output /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary/Components/Components.qmltypes
QQmlComponent: Component is not ready
file:///home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary/loaddependencies.qml:19:1: module "org.example.test" is not installed
[5/6] cd /home/dika/Project/Qt5QMLPlugin_Example/build/qml/UILibrary/Forms && /usr/bin/cmake -E env QML2_IMPORT_PATH="/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary" /usr/lib/x86_64-linux-gnu/qt5/bin/qmlplugindump -nonrelocatable Forms 1.0 /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary -output /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary/Forms/Forms.qmltypes
[6/6] cd /home/dika/Project/Qt5QMLPlugin_Example/build/qml/Pages && /usr/bin/cmake -E env QML2_IMPORT_PATH="/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/org/example" /usr/lib/x86_64-linux-gnu/qt5/bin/qmlplugindump -nonrelocatable Pages 1.0 /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml -output /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/Pages/Pages.qmltypes
FAILED: qml/Pages/CMakeFiles/Pagespluginqmltypes /home/dika/Project/Qt5QMLPlugin_Example/build/qml/Pages/CMakeFiles/Pagespluginqmltypes 
cd /home/dika/Project/Qt5QMLPlugin_Example/build/qml/Pages && /usr/bin/cmake -E env QML2_IMPORT_PATH="/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/UILibrary:/home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/org/example" /usr/lib/x86_64-linux-gnu/qt5/bin/qmlplugindump -nonrelocatable Pages 1.0 /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml -output /home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/Pages/Pages.qmltypes
QQmlComponent: Component is not ready
file:///home/dika/Project/Qt5QMLPlugin_Example/build/output/qml/loaddependencies.qml:18:1: module "org.example.test" is not installed
ninja: build stopped: subcommand failed.
```

</details>

Here's how to reproduce the problem:
```sh
cmake .. -G Ninja && cmake --build . --target all --config Debug --parallel
```
Plus the CI/CD didn’t kick in.
https://github.com/DanuulKa03/Qt5QMLPlugin_Example/actions/runs/15214288945